### PR TITLE
Clarifies the need to install lerna globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ npm install
 2. Bootstrap project with lerna. It will take care of the package's dependencies and trigger prepublish script which builds them
 
 ```
+npm install --g lerna
 lerna bootstrap
+lerna start
 ```
-
-After that you're free to go
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install
 ```
 npm install --g lerna
 lerna bootstrap
-lerna start
+lerna run start
 ```
 
 ----


### PR DESCRIPTION
This repo will be the main place we'll point devs interested in building the project, so instructions here should get someone up to the point of having a locally running version of the app.

Lerna was not in my path after `npm install` and installing it globally was necessary to be able to run `lerna bootstrap`.   